### PR TITLE
added && for docker install lines

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -73,7 +73,7 @@ This installs 17.12 or newer.
 
 ```
 $ curl -sSL get.docker.com | sh && \
-sudo usermod pi -aG docker
+sudo usermod pi -aG docker && \
 newgrp docker
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
line 1 of the docker install commands had `&& \`, so I added it to line 2 to include `newgrp docker` to make it single execution.
## Description
<!--- Describe your changes in detail -->
`&& \` on the second line allows for the user to run all steps in one execution.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It's easier for the end user to run all of this than to wait for the download to complete to resume typing / pasting.
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/k8s-on-raspbian#contributions))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I ran the commands with ` && \` during setup on my end, following this guide.
<!--- Include details of your testing environment, and the tests you ran to -->
Confirmed `docker` group exists after running groups using the updated command.
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have tested this change and prove it works
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/k8s-on-raspbian#contributions) guide
- [x] I have signed-off my commits with `git commit -s`