### PR TITLE
Added note re ip_forward and updated dashboard url

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -367,7 +367,7 @@ subjects:
 This is the development/alternative dashboard which has TLS disabled and is easier to use.
 
 ```
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/alternative/kubernetes-dashboard-arm-head.yaml
+$ kubectl apply -f kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/alternative.yaml
 ```
 
 You can then find the IP and port via `kubectl get svc -n kube-system`. To access this from your laptop you will need to use `kubectl proxy` and navigate to `http://localhost:8001/` on the master, or tunnel to this address with `ssh`.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -75,9 +75,19 @@ You may also need to make a reservation on your router's DHCP table so these add
 
 * Enable `bridge-nf-call-iptables`
 
+
 ```sh
 sudo sysctl net.bridge.bridge-nf-call-iptables=1
 ```
+
+and
+```
+sudo sysctl net.ipv4.ip_forward=1
+```
+
+You might need to run `sudo modprobe br_netfilter` if the either of the above commands gives an error.
+
+
 
 * Install Docker
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For my install (raspbian buster) I had to also set net.ipv4.ip_forward=1 to get networking working between nodes.
Also updated the alternative dashboard url to the current one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixed problems accessing dashboard when it was deployed anywhere other than the master node.
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/k8s-on-raspbian#contributions))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using raspbian buster fresh install and a 3 node cluster.  Not tested on earlier versions of raspbian.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] I have tested this change and prove it works
- [ x] I've read the [CONTRIBUTION](https://github.com/alexellis/k8s-on-raspbian#contributions) guide
- [ x] I have signed-off my commits with `git commit -s`

